### PR TITLE
[Stage 4] REST API layer & OpenAPI

### DIFF
--- a/src/app/api/companies/[id]/route.ts
+++ b/src/app/api/companies/[id]/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import prisma from "@/lib/prisma";
+import { handleApiError, NotFoundError } from "@/lib/api/errors";
+import { requireApiKey } from "@/lib/api/guard";
+import { companyIdSchema, companyResponseSchema, companyUpdateSchema } from "@/schemas/company";
+
+function serializeCompany(company: any) {
+  return companyResponseSchema.parse({
+    id: company.id,
+    name: company.name,
+    website: company.website ?? null,
+    industry: company.industry ?? null,
+    segment: company.segment ?? null,
+    description: company.description ?? null,
+    tags: Array.isArray(company.tags) ? company.tags : [],
+    createdAt: new Date(company.createdAt).toISOString(),
+    updatedAt: new Date(company.updatedAt).toISOString(),
+    deletedAt: company.deletedAt ? new Date(company.deletedAt).toISOString() : null,
+  });
+}
+
+async function getCompanyOrThrow(id: string) {
+  const company = await (prisma as any).company.findUnique({ where: { id } });
+  if (!company || company.deletedAt) {
+    throw new NotFoundError("Company not found");
+  }
+  return company;
+}
+
+export async function GET(request: NextRequest, context: { params: { id: string } }) {
+  try {
+    requireApiKey(request);
+
+    const params = companyIdSchema.parse(context.params);
+    const company = await getCompanyOrThrow(params.id);
+    return NextResponse.json({ data: serializeCompany(company) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function PATCH(request: NextRequest, context: { params: { id: string } }) {
+  try {
+    requireApiKey(request);
+
+    const params = companyIdSchema.parse(context.params);
+    await getCompanyOrThrow(params.id);
+
+    const payload = await request.json();
+    const result = companyUpdateSchema.safeParse(payload);
+    if (!result.success) {
+      throw result.error;
+    }
+
+    const updateData: Record<string, unknown> = {};
+
+    if (Object.prototype.hasOwnProperty.call(result.data, "name")) {
+      updateData.name = result.data.name;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "website")) {
+      updateData.website = result.data.website ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "industry")) {
+      updateData.industry = result.data.industry ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "segment")) {
+      updateData.segment = result.data.segment ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "description")) {
+      updateData.description = result.data.description ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "tags")) {
+      updateData.tags = result.data.tags ?? [];
+    }
+
+    const company = await (prisma as any).company.update({
+      where: { id: params.id },
+      data: updateData,
+    });
+
+    return NextResponse.json({ data: serializeCompany(company) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function DELETE(request: NextRequest, context: { params: { id: string } }) {
+  try {
+    requireApiKey(request);
+
+    const params = companyIdSchema.parse(context.params);
+    await getCompanyOrThrow(params.id);
+
+    const company = await (prisma as any).company.update({
+      where: { id: params.id },
+      data: { deletedAt: new Date() },
+    });
+
+    return NextResponse.json({ data: serializeCompany(company) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import prisma from "@/lib/prisma";
+import { handleApiError } from "@/lib/api/errors";
+import { requireApiKey } from "@/lib/api/guard";
+import { buildPaginationMeta, parsePaginationParams } from "@/lib/api/pagination";
+import {
+  companyCreateSchema,
+  companyResponseSchema,
+  companySearchSchema,
+} from "@/schemas/company";
+
+function serializeCompany(company: any) {
+  return companyResponseSchema.parse({
+    id: company.id,
+    name: company.name,
+    website: company.website ?? null,
+    industry: company.industry ?? null,
+    segment: company.segment ?? null,
+    description: company.description ?? null,
+    tags: Array.isArray(company.tags) ? company.tags : [],
+    createdAt: new Date(company.createdAt).toISOString(),
+    updatedAt: new Date(company.updatedAt).toISOString(),
+    deletedAt: company.deletedAt ? new Date(company.deletedAt).toISOString() : null,
+  });
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    requireApiKey(request);
+
+    const pagination = parsePaginationParams(request.nextUrl.searchParams);
+    const query = companySearchSchema.parse({
+      search: request.nextUrl.searchParams.get("search") ?? undefined,
+    });
+
+    const where: Record<string, unknown> = { deletedAt: null };
+
+    if (query.search) {
+      where.OR = [
+        { name: { contains: query.search, mode: "insensitive" } },
+        { website: { contains: query.search, mode: "insensitive" } },
+        { industry: { contains: query.search, mode: "insensitive" } },
+        { segment: { contains: query.search, mode: "insensitive" } },
+      ];
+    }
+
+    const [items, total] = await Promise.all([
+      (prisma as any).company.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip: pagination.skip,
+        take: pagination.take,
+      }),
+      (prisma as any).company.count({ where }),
+    ]);
+
+    const data = items.map(serializeCompany);
+
+    return NextResponse.json({
+      data,
+      meta: buildPaginationMeta(total, pagination),
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    requireApiKey(request);
+
+    const payload = await request.json();
+    const result = companyCreateSchema.safeParse(payload);
+    if (!result.success) {
+      throw result.error;
+    }
+
+    const company = await (prisma as any).company.create({
+      data: {
+        name: result.data.name,
+        website: result.data.website ?? null,
+        industry: result.data.industry ?? null,
+        segment: result.data.segment ?? null,
+        description: result.data.description ?? null,
+        tags: result.data.tags ?? [],
+      },
+    });
+
+    return NextResponse.json({ data: serializeCompany(company) }, { status: 201 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import prisma from "@/lib/prisma";
+import { handleApiError, NotFoundError } from "@/lib/api/errors";
+import { requireApiKey } from "@/lib/api/guard";
+import { contactIdSchema, contactResponseSchema, contactUpdateSchema } from "@/schemas/contact";
+
+function serializeContact(contact: any) {
+  return contactResponseSchema.parse({
+    id: contact.id,
+    companyId: contact.companyId,
+    firstName: contact.firstName,
+    lastName: contact.lastName ?? null,
+    email: contact.email ?? null,
+    phone: contact.phone ?? null,
+    jobTitle: contact.jobTitle ?? null,
+    segment: contact.segment ?? null,
+    tags: Array.isArray(contact.tags) ? contact.tags : [],
+    notes: contact.notes ?? null,
+    createdAt: new Date(contact.createdAt).toISOString(),
+    updatedAt: new Date(contact.updatedAt).toISOString(),
+    deletedAt: contact.deletedAt ? new Date(contact.deletedAt).toISOString() : null,
+  });
+}
+
+async function getContactOrThrow(id: string) {
+  const contact = await (prisma as any).contact.findUnique({ where: { id } });
+  if (!contact || contact.deletedAt) {
+    throw new NotFoundError("Contact not found");
+  }
+  return contact;
+}
+
+async function ensureCompanyExists(companyId: string) {
+  const company = await (prisma as any).company.findUnique({ where: { id: companyId } });
+  if (!company || company.deletedAt) {
+    throw new NotFoundError("Company not found");
+  }
+  return company;
+}
+
+export async function GET(request: NextRequest, context: { params: { id: string } }) {
+  try {
+    requireApiKey(request);
+
+    const params = contactIdSchema.parse(context.params);
+    const contact = await getContactOrThrow(params.id);
+
+    return NextResponse.json({ data: serializeContact(contact) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function PATCH(request: NextRequest, context: { params: { id: string } }) {
+  try {
+    requireApiKey(request);
+
+    const params = contactIdSchema.parse(context.params);
+    await getContactOrThrow(params.id);
+
+    const payload = await request.json();
+    const result = contactUpdateSchema.safeParse(payload);
+    if (!result.success) {
+      throw result.error;
+    }
+
+    if (result.data.companyId) {
+      await ensureCompanyExists(result.data.companyId);
+    }
+
+    const updateData: Record<string, unknown> = {};
+
+    if (Object.prototype.hasOwnProperty.call(result.data, "companyId")) {
+      updateData.companyId = result.data.companyId;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "firstName")) {
+      updateData.firstName = result.data.firstName;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "lastName")) {
+      updateData.lastName = result.data.lastName ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "email")) {
+      updateData.email = result.data.email ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "phone")) {
+      updateData.phone = result.data.phone ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "jobTitle")) {
+      updateData.jobTitle = result.data.jobTitle ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "segment")) {
+      updateData.segment = result.data.segment ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "tags")) {
+      updateData.tags = result.data.tags ?? [];
+    }
+    if (Object.prototype.hasOwnProperty.call(result.data, "notes")) {
+      updateData.notes = result.data.notes ?? null;
+    }
+
+    const contact = await (prisma as any).contact.update({
+      where: { id: params.id },
+      data: updateData,
+    });
+
+    return NextResponse.json({ data: serializeContact(contact) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function DELETE(request: NextRequest, context: { params: { id: string } }) {
+  try {
+    requireApiKey(request);
+
+    const params = contactIdSchema.parse(context.params);
+    await getContactOrThrow(params.id);
+
+    const contact = await (prisma as any).contact.update({
+      where: { id: params.id },
+      data: { deletedAt: new Date() },
+    });
+
+    return NextResponse.json({ data: serializeContact(contact) });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import prisma from "@/lib/prisma";
+import { handleApiError, NotFoundError } from "@/lib/api/errors";
+import { requireApiKey } from "@/lib/api/guard";
+import { buildPaginationMeta, parsePaginationParams } from "@/lib/api/pagination";
+import { contactCreateSchema, contactFilterSchema, contactResponseSchema } from "@/schemas/contact";
+
+function serializeContact(contact: any) {
+  return contactResponseSchema.parse({
+    id: contact.id,
+    companyId: contact.companyId,
+    firstName: contact.firstName,
+    lastName: contact.lastName ?? null,
+    email: contact.email ?? null,
+    phone: contact.phone ?? null,
+    jobTitle: contact.jobTitle ?? null,
+    segment: contact.segment ?? null,
+    tags: Array.isArray(contact.tags) ? contact.tags : [],
+    notes: contact.notes ?? null,
+    createdAt: new Date(contact.createdAt).toISOString(),
+    updatedAt: new Date(contact.updatedAt).toISOString(),
+    deletedAt: contact.deletedAt ? new Date(contact.deletedAt).toISOString() : null,
+  });
+}
+
+async function ensureCompanyExists(companyId: string) {
+  const company = await (prisma as any).company.findUnique({ where: { id: companyId } });
+  if (!company || company.deletedAt) {
+    throw new NotFoundError("Company not found");
+  }
+  return company;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    requireApiKey(request);
+
+    const pagination = parsePaginationParams(request.nextUrl.searchParams);
+    const filters = contactFilterSchema.parse({
+      companyId: request.nextUrl.searchParams.get("companyId") ?? undefined,
+      segment: request.nextUrl.searchParams.get("segment") ?? undefined,
+      tag: request.nextUrl.searchParams.get("tag") ?? undefined,
+      email: request.nextUrl.searchParams.get("email") ?? undefined,
+      phone: request.nextUrl.searchParams.get("phone") ?? undefined,
+    });
+
+    const tags = request.nextUrl.searchParams.getAll("tag");
+
+    const where: Record<string, unknown> = { deletedAt: null };
+
+    if (filters.companyId) {
+      where.companyId = filters.companyId;
+    }
+    if (filters.segment) {
+      where.segment = { equals: filters.segment, mode: "insensitive" };
+    }
+    if (filters.email) {
+      where.email = { contains: filters.email, mode: "insensitive" };
+    }
+    if (filters.phone) {
+      where.phone = { contains: filters.phone, mode: "insensitive" };
+    }
+
+    const normalizedTags = tags.length ? tags : filters.tag ? [filters.tag] : [];
+    if (normalizedTags.length) {
+      where.tags = { hasSome: normalizedTags };
+    }
+
+    const [items, total] = await Promise.all([
+      (prisma as any).contact.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip: pagination.skip,
+        take: pagination.take,
+      }),
+      (prisma as any).contact.count({ where }),
+    ]);
+
+    const data = items.map(serializeContact);
+
+    return NextResponse.json({
+      data,
+      meta: buildPaginationMeta(total, pagination),
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    requireApiKey(request);
+
+    const payload = await request.json();
+    const result = contactCreateSchema.safeParse(payload);
+    if (!result.success) {
+      throw result.error;
+    }
+
+    await ensureCompanyExists(result.data.companyId);
+
+    const contact = await (prisma as any).contact.create({
+      data: {
+        companyId: result.data.companyId,
+        firstName: result.data.firstName,
+        lastName: result.data.lastName ?? null,
+        email: result.data.email ?? null,
+        phone: result.data.phone ?? null,
+        jobTitle: result.data.jobTitle ?? null,
+        segment: result.data.segment ?? null,
+        tags: result.data.tags ?? [],
+        notes: result.data.notes ?? null,
+      },
+    });
+
+    return NextResponse.json({ data: serializeContact(contact) }, { status: 201 });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/src/app/api/openapi/route.ts
+++ b/src/app/api/openapi/route.ts
@@ -1,0 +1,497 @@
+import { NextResponse } from "next/server";
+
+const paginationMetaSchema = {
+  type: "object",
+  properties: {
+    page: { type: "integer", minimum: 1 },
+    pageSize: { type: "integer", minimum: 1 },
+    totalItems: { type: "integer", minimum: 0 },
+    totalPages: { type: "integer", minimum: 1 },
+    hasNextPage: { type: "boolean" },
+    hasPreviousPage: { type: "boolean" },
+  },
+  required: ["page", "pageSize", "totalItems", "totalPages", "hasNextPage", "hasPreviousPage"],
+};
+
+const companySchema = {
+  type: "object",
+  properties: {
+    id: { type: "string", format: "uuid" },
+    name: { type: "string" },
+    website: { type: ["string", "null"], format: "uri" },
+    industry: { type: ["string", "null"] },
+    segment: { type: ["string", "null"] },
+    description: { type: ["string", "null"] },
+    tags: { type: "array", items: { type: "string" } },
+    createdAt: { type: "string", format: "date-time" },
+    updatedAt: { type: "string", format: "date-time" },
+    deletedAt: { type: ["string", "null"], format: "date-time" },
+  },
+  required: [
+    "id",
+    "name",
+    "website",
+    "industry",
+    "segment",
+    "description",
+    "tags",
+    "createdAt",
+    "updatedAt",
+    "deletedAt",
+  ],
+};
+
+const contactSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string", format: "uuid" },
+    companyId: { type: "string", format: "uuid" },
+    firstName: { type: "string" },
+    lastName: { type: ["string", "null"] },
+    email: { type: ["string", "null"], format: "email" },
+    phone: { type: ["string", "null"] },
+    jobTitle: { type: ["string", "null"] },
+    segment: { type: ["string", "null"] },
+    tags: { type: "array", items: { type: "string" } },
+    notes: { type: ["string", "null"] },
+    createdAt: { type: "string", format: "date-time" },
+    updatedAt: { type: "string", format: "date-time" },
+    deletedAt: { type: ["string", "null"], format: "date-time" },
+  },
+  required: [
+    "id",
+    "companyId",
+    "firstName",
+    "lastName",
+    "email",
+    "phone",
+    "jobTitle",
+    "segment",
+    "tags",
+    "notes",
+    "createdAt",
+    "updatedAt",
+    "deletedAt",
+  ],
+};
+
+const errorSchema = {
+  type: "object",
+  properties: {
+    error: {
+      type: "object",
+      properties: {
+        code: { type: "string" },
+        message: { type: "string" },
+        details: {},
+      },
+      required: ["code", "message"],
+    },
+  },
+  required: ["error"],
+};
+
+const document = {
+  openapi: "3.1.0",
+  info: {
+    title: "CRM REST API",
+    version: "1.0.0",
+    description: "CRUD endpoints for companies and contacts in the CRM system.",
+  },
+  servers: [
+    {
+      url: process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000",
+    },
+  ],
+  security: [{ ApiKeyAuth: [] }],
+  components: {
+    securitySchemes: {
+      ApiKeyAuth: {
+        type: "apiKey",
+        in: "header",
+        name: "X-API-Key",
+      },
+    },
+    schemas: {
+      Company: companySchema,
+      Contact: contactSchema,
+      PaginationMeta: paginationMetaSchema,
+      ErrorResponse: errorSchema,
+      CompanyCreateInput: {
+        type: "object",
+        properties: {
+          name: { type: "string", minLength: 1 },
+          website: { type: "string", format: "uri" },
+          industry: { type: "string" },
+          segment: { type: "string" },
+          description: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+        },
+        required: ["name"],
+        additionalProperties: false,
+      },
+      CompanyUpdateInput: {
+        allOf: [
+          { $ref: "#/components/schemas/CompanyCreateInput" },
+          { type: "object", required: [] },
+        ],
+      },
+      ContactCreateInput: {
+        type: "object",
+        properties: {
+          companyId: { type: "string", format: "uuid" },
+          firstName: { type: "string", minLength: 1 },
+          lastName: { type: "string" },
+          email: { type: "string", format: "email" },
+          phone: { type: "string" },
+          jobTitle: { type: "string" },
+          segment: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+          notes: { type: "string" },
+        },
+        required: ["companyId", "firstName"],
+        additionalProperties: false,
+      },
+      ContactUpdateInput: {
+        allOf: [
+          { $ref: "#/components/schemas/ContactCreateInput" },
+          { type: "object", required: [] },
+        ],
+      },
+    },
+  },
+  paths: {
+    "/api/companies": {
+      get: {
+        summary: "List companies",
+        parameters: [
+          {
+            name: "search",
+            in: "query",
+            schema: { type: "string" },
+            description: "Full-text search across name, website, industry, and segment.",
+          },
+          {
+            name: "page",
+            in: "query",
+            schema: { type: "integer", minimum: 1, default: 1 },
+          },
+          {
+            name: "pageSize",
+            in: "query",
+            schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "A paginated list of companies.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: { type: "array", items: { $ref: "#/components/schemas/Company" } },
+                    meta: { $ref: "#/components/schemas/PaginationMeta" },
+                  },
+                  required: ["data", "meta"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+      post: {
+        summary: "Create a company",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CompanyCreateInput" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Company created",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { data: { $ref: "#/components/schemas/Company" } },
+                  required: ["data"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+    },
+    "/api/companies/{id}": {
+      parameters: [
+        {
+          name: "id",
+          in: "path",
+          required: true,
+          schema: { type: "string", format: "uuid" },
+        },
+      ],
+      get: {
+        summary: "Retrieve a company",
+        responses: {
+          "200": {
+            description: "Company details",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { data: { $ref: "#/components/schemas/Company" } },
+                  required: ["data"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+      patch: {
+        summary: "Update a company",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CompanyUpdateInput" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Updated company",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { data: { $ref: "#/components/schemas/Company" } },
+                  required: ["data"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+      delete: {
+        summary: "Soft delete a company",
+        responses: {
+          "200": {
+            description: "Soft deleted company",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { data: { $ref: "#/components/schemas/Company" } },
+                  required: ["data"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+    },
+    "/api/contacts": {
+      get: {
+        summary: "List contacts",
+        parameters: [
+          {
+            name: "companyId",
+            in: "query",
+            schema: { type: "string", format: "uuid" },
+          },
+          {
+            name: "segment",
+            in: "query",
+            schema: { type: "string" },
+          },
+          {
+            name: "tag",
+            in: "query",
+            schema: { type: "string" },
+            description: "Filter by tag. Repeat parameter to match multiple tags.",
+          },
+          {
+            name: "email",
+            in: "query",
+            schema: { type: "string", format: "email" },
+          },
+          {
+            name: "phone",
+            in: "query",
+            schema: { type: "string" },
+          },
+          {
+            name: "page",
+            in: "query",
+            schema: { type: "integer", minimum: 1, default: 1 },
+          },
+          {
+            name: "pageSize",
+            in: "query",
+            schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "A paginated list of contacts.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: { type: "array", items: { $ref: "#/components/schemas/Contact" } },
+                    meta: { $ref: "#/components/schemas/PaginationMeta" },
+                  },
+                  required: ["data", "meta"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+      post: {
+        summary: "Create a contact",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ContactCreateInput" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Contact created",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { data: { $ref: "#/components/schemas/Contact" } },
+                  required: ["data"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+    },
+    "/api/contacts/{id}": {
+      parameters: [
+        {
+          name: "id",
+          in: "path",
+          required: true,
+          schema: { type: "string", format: "uuid" },
+        },
+      ],
+      get: {
+        summary: "Retrieve a contact",
+        responses: {
+          "200": {
+            description: "Contact details",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { data: { $ref: "#/components/schemas/Contact" } },
+                  required: ["data"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+      patch: {
+        summary: "Update a contact",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ContactUpdateInput" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Updated contact",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { data: { $ref: "#/components/schemas/Contact" } },
+                  required: ["data"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+      delete: {
+        summary: "Soft delete a contact",
+        responses: {
+          "200": {
+            description: "Soft deleted contact",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { data: { $ref: "#/components/schemas/Contact" } },
+                  required: ["data"],
+                },
+              },
+            },
+          },
+          default: {
+            description: "Error",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
+          },
+        },
+      },
+    },
+  },
+};
+
+export async function GET() {
+  return NextResponse.json(document);
+}

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+export type ErrorBody = {
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+};
+
+export class ApiError extends Error {
+  public readonly status: number;
+
+  public readonly code: string;
+
+  public readonly details?: unknown;
+
+  constructor(status: number, code: string, message: string, details?: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export class NotFoundError extends ApiError {
+  constructor(message = "Resource not found", details?: unknown) {
+    super(404, "not_found", message, details);
+  }
+}
+
+export class UnauthorizedError extends ApiError {
+  constructor(message = "Unauthorized", details?: unknown) {
+    super(401, "unauthorized", message, details);
+  }
+}
+
+export class ForbiddenError extends ApiError {
+  constructor(message = "Forbidden", details?: unknown) {
+    super(403, "forbidden", message, details);
+  }
+}
+
+export class BadRequestError extends ApiError {
+  constructor(message = "Bad request", details?: unknown) {
+    super(400, "bad_request", message, details);
+  }
+}
+
+export function normalizeError(error: unknown): { status: number; body: ErrorBody } {
+  if (error instanceof ApiError) {
+    return {
+      status: error.status,
+      body: {
+        error: {
+          code: error.code,
+          message: error.message,
+          ...(error.details === undefined ? {} : { details: error.details }),
+        },
+      },
+    };
+  }
+
+  if (error instanceof ZodError) {
+    return {
+      status: 422,
+      body: {
+        error: {
+          code: "validation_error",
+          message: "Request validation failed",
+          details: error.flatten(),
+        },
+      },
+    };
+  }
+
+  console.error("Unhandled API error", error);
+
+  return {
+    status: 500,
+    body: {
+      error: {
+        code: "internal_server_error",
+        message: "An unexpected error occurred",
+      },
+    },
+  };
+}
+
+export function handleApiError(error: unknown) {
+  const { status, body } = normalizeError(error);
+  return NextResponse.json(body, { status });
+}

--- a/src/lib/api/guard.ts
+++ b/src/lib/api/guard.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from "next/server";
+
+import { ApiError, UnauthorizedError } from "./errors";
+
+const API_KEY_HEADER = "x-api-key";
+
+function resolveExpectedKeys(): string[] {
+  const raw = process.env.INTERNAL_API_KEY || process.env.CRM_API_KEY;
+  if (!raw) {
+    throw new ApiError(500, "api_key_not_configured", "API key guard is not configured");
+  }
+
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function extractPresentedKey(request: NextRequest): string | null {
+  const headerKey = request.headers.get(API_KEY_HEADER);
+  if (headerKey) {
+    return headerKey;
+  }
+
+  const authorization = request.headers.get("authorization");
+  if (authorization?.toLowerCase().startsWith("bearer ")) {
+    return authorization.slice(7).trim();
+  }
+
+  return null;
+}
+
+export function requireApiKey(request: NextRequest): string {
+  const provided = extractPresentedKey(request);
+  if (!provided) {
+    throw new UnauthorizedError("Missing API key");
+  }
+
+  const expectedKeys = resolveExpectedKeys();
+
+  if (!expectedKeys.includes(provided)) {
+    throw new UnauthorizedError("Invalid API key");
+  }
+
+  return provided;
+}

--- a/src/lib/api/pagination.ts
+++ b/src/lib/api/pagination.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+const paginationSchema = z
+  .object({
+    page: z.coerce.number().int().min(1).default(1),
+    pageSize: z.coerce.number().int().min(1).max(100).default(20),
+  })
+  .strict();
+
+export type PaginationParams = z.infer<typeof paginationSchema> & {
+  skip: number;
+  take: number;
+};
+
+export type PaginationMeta = {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+};
+
+export function parsePaginationParams(searchParams: URLSearchParams): PaginationParams {
+  const result = paginationSchema.safeParse({
+    page: searchParams.get("page") ?? undefined,
+    pageSize: searchParams.get("pageSize") ?? undefined,
+  });
+
+  if (!result.success) {
+    throw result.error;
+  }
+
+  const { page, pageSize } = result.data;
+
+  return {
+    page,
+    pageSize,
+    skip: (page - 1) * pageSize,
+    take: pageSize,
+  };
+}
+
+export function buildPaginationMeta(totalItems: number, params: PaginationParams): PaginationMeta {
+  const totalPages = Math.max(1, Math.ceil(totalItems / params.pageSize));
+  return {
+    page: params.page,
+    pageSize: params.pageSize,
+    totalItems,
+    totalPages,
+    hasNextPage: params.page < totalPages,
+    hasPreviousPage: params.page > 1,
+  };
+}

--- a/src/schemas/company.ts
+++ b/src/schemas/company.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+const tagSchema = z.string().min(1).max(64);
+
+export const companyIdSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const companyCreateSchema = z
+  .object({
+    name: z.string().min(1).max(255),
+    website: z.string().url().optional(),
+    industry: z.string().min(1).max(128).optional(),
+    segment: z.string().min(1).max(64).optional(),
+    description: z.string().min(1).max(1024).optional(),
+    tags: z.array(tagSchema).optional(),
+  })
+  .strict();
+
+export const companyUpdateSchema = companyCreateSchema.partial();
+
+export const companySearchSchema = z
+  .object({
+    search: z.string().min(1).max(255).optional(),
+  })
+  .strict();
+
+export const companyResponseSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  website: z.string().url().nullable(),
+  industry: z.string().nullable(),
+  segment: z.string().nullable(),
+  description: z.string().nullable(),
+  tags: z.array(tagSchema),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type CompanyIdParams = z.infer<typeof companyIdSchema>;
+export type CompanyCreateInput = z.infer<typeof companyCreateSchema>;
+export type CompanyUpdateInput = z.infer<typeof companyUpdateSchema>;
+export type CompanyResponse = z.infer<typeof companyResponseSchema>;

--- a/src/schemas/contact.ts
+++ b/src/schemas/contact.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+const tagSchema = z.string().min(1).max(64);
+
+const contactCoreSchema = z
+  .object({
+    companyId: z.string().uuid(),
+    firstName: z.string().min(1).max(120),
+    lastName: z.string().min(1).max(120).optional(),
+    email: z.string().email().optional(),
+    phone: z.string().min(5).max(32).optional(),
+    jobTitle: z.string().min(1).max(120).optional(),
+    segment: z.string().min(1).max(64).optional(),
+    tags: z.array(tagSchema).optional(),
+    notes: z.string().min(1).max(1024).optional(),
+  })
+  .strict();
+
+export const contactIdSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const contactCreateSchema = contactCoreSchema.superRefine((value, ctx) => {
+  if (!value.email && !value.phone) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Either email or phone must be provided",
+      path: ["email"],
+    });
+  }
+});
+
+export const contactUpdateSchema = contactCoreSchema
+  .partial()
+  .superRefine((value, ctx) => {
+    if (value.email === undefined && value.phone === undefined) {
+      return;
+    }
+
+    if (!value.email && !value.phone) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Either email or phone must be provided",
+        path: ["email"],
+      });
+    }
+  });
+
+export const contactFilterSchema = z
+  .object({
+    companyId: z.string().uuid().optional(),
+    segment: z.string().min(1).max(64).optional(),
+    tag: z.string().min(1).max(64).optional(),
+    email: z.string().email().optional(),
+    phone: z.string().min(5).max(32).optional(),
+  })
+  .strict();
+
+export const contactResponseSchema = z.object({
+  id: z.string().uuid(),
+  companyId: z.string().uuid(),
+  firstName: z.string(),
+  lastName: z.string().nullable(),
+  email: z.string().email().nullable(),
+  phone: z.string().nullable(),
+  jobTitle: z.string().nullable(),
+  segment: z.string().nullable(),
+  tags: z.array(tagSchema),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type ContactIdParams = z.infer<typeof contactIdSchema>;
+export type ContactCreateInput = z.infer<typeof contactCreateSchema>;
+export type ContactUpdateInput = z.infer<typeof contactUpdateSchema>;
+export type ContactResponse = z.infer<typeof contactResponseSchema>;


### PR DESCRIPTION
## Summary
- add API utilities for normalized errors, pagination parsing, and API key guard to secure route handlers.
- implement `/api/companies` and `/api/contacts` CRUD handlers with Zod validation, Prisma access, and soft-delete semantics.
- publish OpenAPI 3.1 spec covering the new endpoints to back the API documentation pipeline.

## File list
- `src/lib/api/errors.ts`
- `src/lib/api/pagination.ts`
- `src/lib/api/guard.ts`
- `src/schemas/company.ts`
- `src/schemas/contact.ts`
- `src/app/api/companies/route.ts`
- `src/app/api/companies/[id]/route.ts`
- `src/app/api/contacts/route.ts`
- `src/app/api/contacts/[id]/route.ts`
- `src/app/api/openapi/route.ts`

## How to test
```bash
pnpm install --frozen-lockfile
pnpm prisma generate || true
pnpm -w build
pnpm test -w || true
```

## Definition of Done
- [x] OpenAPI includes Companies & Contacts CRUD endpoints
- [ ] `/api-docs` renders Scalar viewer
- [ ] CRUD flows verified end-to-end via automated tests

## Risks / Rollback
- Requires Prisma models for companies/contacts to exist; if schema diverges these handlers will fail at runtime.
- API key guard depends on configuring `INTERNAL_API_KEY`/`CRM_API_KEY`; missing env will block access.
- Roll back by reverting the commit if deployment surfaces issues.


------
https://chatgpt.com/codex/tasks/task_b_68da299545d48329b9a8afb27c8a1c8a